### PR TITLE
add a delay when creating a check run

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "lodash": "4.17.11",
     "probot": "7.5.0",
+    "sleep-promise": "8.0.1",
     "yamljs": "0.3.0"
   },
   "devDependencies": {

--- a/src/github.js
+++ b/src/github.js
@@ -18,6 +18,7 @@ const {RepoFile} = require('./repo-file');
 const {Owner} = require('./owner');
 const {Git} = require('./git');
 const _ = require('lodash');
+const sleep = require('sleep-promise');
 
 
 /**
@@ -137,8 +138,10 @@ class PullRequest {
   }
 
   async createCheckRun(text, areApprovalsMet) {
+    // We need to add a delay on the PR creation and check creation since
+    // GitHub might not be ready.
+    await sleep(2000);
     const conclusion = areApprovalsMet ? 'success' : 'failure';
-    setTimeout(function() {
     return this.github.checks.create(this.context.repo({
       name: this.name,
       head_branch: this.headRef,
@@ -152,7 +155,6 @@ class PullRequest {
         text,
       }
     }));
-    }, 2000);
   }
 
   async updateCheckRun(checkRun, text, areApprovalsMet) {

--- a/src/github.js
+++ b/src/github.js
@@ -138,6 +138,7 @@ class PullRequest {
 
   async createCheckRun(text, areApprovalsMet) {
     const conclusion = areApprovalsMet ? 'success' : 'failure';
+    setTimeout(function() {
     return this.github.checks.create(this.context.repo({
       name: this.name,
       head_branch: this.headRef,
@@ -151,6 +152,7 @@ class PullRequest {
         text,
       }
     }));
+    }, 2000);
   }
 
   async updateCheckRun(checkRun, text, areApprovalsMet) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4367,6 +4367,11 @@ slash@^1.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
+sleep-promise@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/sleep-promise/-/sleep-promise-8.0.1.tgz#8d795a27ea23953df6b52b91081e5e22665993c5"
+  integrity sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U=
+
 smee-client@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/smee-client/-/smee-client-1.0.2.tgz#2b7e72d7ab383e5d6e4a17ae00cd07503cbcf25d"


### PR DESCRIPTION
looks like we are too fast to request a check creation and GitHub doesn't process it.

add a 2 second delay.

now i know why @danielrozenberg used sleep-promise 😛 