### PR TITLE
remove list of enumerated required approvers on checks tab if a user in the list has approved

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = app => {
   app.on(['check_run.rerequested'], onCheckRunRerequest)
 
   async function onPullRequest(context) {
+    context.log.debug('IM HERE aaaa');
     // Only allow PR's from our fork
     const disallowed = !/repos\/(erwinmombay|rsimha)/.test(context.payload.pull_request.url);
     context.log.debug('[disallowed?]', disallowed, context.payload.pull_request.url);
@@ -16,6 +17,7 @@ module.exports = app => {
 
   async function onCheckRunRerequest(context) {
     const payload = context.payload;
+    context.log.debug('IM HERE bbb', payload);
     const pr = await PullRequest.get(context, payload.repository.owner.login,
       payload.repository.name, payload.check_run.check_suite.pull_requests[0].number);
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ module.exports = app => {
   app.on(['check_run.rerequested'], onCheckRunRerequest)
 
   async function onPullRequest(context) {
-    context.log.debug('IM HERE aaaa');
     // Only allow PR's from our fork
     const disallowed = !/repos\/(erwinmombay|rsimha)/.test(context.payload.pull_request.url);
     context.log.debug('[disallowed?]', disallowed, context.payload.pull_request.url);
@@ -17,7 +16,6 @@ module.exports = app => {
 
   async function onCheckRunRerequest(context) {
     const payload = context.payload;
-    context.log.debug('IM HERE bbb', payload);
     const pr = await PullRequest.get(context, payload.repository.owner.login,
       payload.repository.name, payload.check_run.check_suite.pull_requests[0].number);
 

--- a/src/github.js
+++ b/src/github.js
@@ -206,13 +206,18 @@ class PullRequest {
    * @return {string}
    */
   buildCheckOutput(prInfo) {
-    let text = Object.values(prInfo.fileOwners).map(fileOwner => {
-      const fileOwnerHeader = `## possible reviewers: ${fileOwner.owner.dirOwners.join(',')}\n`;
-      const files = fileOwner.files.map(file => {
-        return ` - ${file.path}\n`;
-      });
-      return `\n${fileOwnerHeader}${files}`;
-    }).join('  ');
+    let text = Object.values(prInfo.fileOwners)
+      .filter(fileOwner => {
+        // Omit sections that has a required reviewer who has approved.
+        return !_.intersection(prInfo.reviewersWhoApproved,
+            fileOwner.owner.dirOwners).length;
+      }).map(fileOwner => {
+        const fileOwnerHeader = `## possible reviewers: ${fileOwner.owner.dirOwners.join(',')}\n`;
+        const files = fileOwner.files.map(file => {
+          return ` - ${file.path}\n`;
+        });
+        return `\n${fileOwnerHeader}${files}`;
+      }).join('  ');
     this.context.log.debug('[buildCheckOutput]', text);
     return text;
   }

--- a/test/fixtures/reviews.35.approved.json
+++ b/test/fixtures/reviews.35.approved.json
@@ -1,0 +1,41 @@
+[
+    {
+        "id": 208194465,
+        "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjA4MTk0NDY1",
+        "user": {
+            "login": "erwinmombay",
+            "id": 354746,
+            "node_id": "MDQ6VXNlcjM1NDc0Ng==",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/354746?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/erwinmombay",
+            "html_url": "https://github.com/erwinmombay",
+            "followers_url": "https://api.github.com/users/erwinmombay/followers",
+            "following_url": "https://api.github.com/users/erwinmombay/following{/other_user}",
+            "gists_url": "https://api.github.com/users/erwinmombay/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/erwinmombay/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/erwinmombay/subscriptions",
+            "organizations_url": "https://api.github.com/users/erwinmombay/orgs",
+            "repos_url": "https://api.github.com/users/erwinmombay/repos",
+            "events_url": "https://api.github.com/users/erwinmombay/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/erwinmombay/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "body": "",
+        "state": "APPROVED",
+        "html_url": "https://github.com/erwinmombay/github-owners-bot-test-repo/pull/35#pullrequestreview-208194465",
+        "pull_request_url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/pulls/35",
+        "author_association": "OWNER",
+        "_links": {
+            "html": {
+                "href": "https://github.com/erwinmombay/github-owners-bot-test-repo/pull/35#pullrequestreview-208194465"
+            },
+            "pull_request": {
+                "href": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/pulls/35"
+            }
+        },
+        "submitted_at": "2019-02-26T20:39:13Z",
+        "commit_id": "9272f18514cbd3fa935b3ced62ae1c2bf6efa76d"
+    }
+]


### PR DESCRIPTION
if a user has already approved, remove the fileset list where that approver is required from the check tab

this makes it so that the list in the `checks` tab are only the list of people you still need a review and approvals from