### PR TITLE
Fix processing of check runs when there are multiple check suites

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ module.exports = app => {
   app.on(['pull_request.opened', 'pull_request.synchronized'], onPullRequest)
   app.on('check_run.rerequested', onCheckRunRerequest)
   app.on('pull_request_review.submitted', onPullRequestReview);
+  app.log('initialized');
+  app.log('initialized');
+  app.log('initialized');
+  app.log('initialized');
+  app.log('initialized');
+  app.log('initialized');
 
   async function onPullRequest(context) {
     context.log('hello world');

--- a/index.js
+++ b/index.js
@@ -14,12 +14,6 @@ module.exports = app => {
   });
 
   async function onPullRequest(context) {
-    // Only allow PR's from our for
-    const disallowed = !/repos\/(erwinmombay|rsimha)/.test(context.payload.pull_request.url);
-    context.log.debug('[disallowed?]', disallowed, context.payload.pull_request.url);
-    if (disallowed) {
-      return;
-    }
     return await processPullRequest(context, context.payload.pull_request);
   }
 

--- a/index.js
+++ b/index.js
@@ -4,19 +4,14 @@ module.exports = app => {
   app.on(['pull_request.opened', 'pull_request.synchronized'], onPullRequest)
   app.on('check_run.rerequested', onCheckRunRerequest)
   app.on('pull_request_review.submitted', onPullRequestReview);
-  app.log('initialized');
-  app.log('initialized');
-  app.log('initialized');
-  app.log('initialized');
-  app.log('initialized');
-  app.log('initialized');
+
+  app.log.target.addStream({
+    name: 'erwin-custom-stream',
+    stream: process.stdout,
+    level: 'trace'
+  });
 
   async function onPullRequest(context) {
-    context.log('hello world');
-    context.log('hello world');
-    context.log('hello world');
-    context.log('hello world');
-    context.log('hello world');
     return await processPullRequest(context, context.payload.pull_request);
   }
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,12 @@ module.exports = app => {
   });
 
   async function onPullRequest(context) {
+    // Only allow PR's from our for
+    const disallowed = !/repos\/(erwinmombay|rsimha)/.test(context.payload.pull_request.url);
+    context.log.debug('[disallowed?]', disallowed, context.payload.pull_request.url);
+    if (disallowed) {
+      return;
+    }
     return await processPullRequest(context, context.payload.pull_request);
   }
 

--- a/index.js
+++ b/index.js
@@ -5,10 +5,12 @@ module.exports = app => {
   app.on('check_run.rerequested', onCheckRunRerequest)
   app.on('pull_request_review.submitted', onPullRequestReview);
 
+  // Probot does not stream properly to GCE logs so we need to hook into
+  // bunyan explicitly and stream it to process.stdout.
   app.log.target.addStream({
-    name: 'erwin-custom-stream',
+    name: 'app-custom-stream',
     stream: process.stdout,
-    level: 'trace'
+    level: process.LOG_LEVEL || 'info',
   });
 
   async function onPullRequest(context) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,11 @@ module.exports = app => {
   app.on('pull_request_review.submitted', onPullRequestReview);
 
   async function onPullRequest(context) {
+    context.log('hello world');
+    context.log('hello world');
+    context.log('hello world');
+    context.log('hello world');
+    context.log('hello world');
     return await processPullRequest(context, context.payload.pull_request);
   }
 

--- a/src/github.js
+++ b/src/github.js
@@ -183,7 +183,7 @@ class PullRequest {
     const res = await this.github.checks.listForRef({
       owner: this.owner,
       repo: this.repo,
-      ref: this.headRef,
+      ref: this.headSha,
     });
     this.context.log.debug('[getCheckRun]', res);
     return res.data;
@@ -195,7 +195,7 @@ class PullRequest {
   hasCheckRun(checkRuns) {
     const hasCheckRun = checkRuns.total_count > 0;
     const [checkRun] = checkRuns.check_runs.filter(x => {
-      return x.head_sha === this.headSha;
+      return x.head_sha === this.headSha && /owners bot/i.test(x.name);
     });
     const tuple = {hasCheckRun: hasCheckRun && !!checkRun, checkRun};
     this.context.log.debug('[hasCheckRun]', tuple);

--- a/src/github.js
+++ b/src/github.js
@@ -30,6 +30,8 @@ class PullRequest {
 
     this.name = 'ampproject/owners-check';
 
+    this.nameMatcher = new RegExp('owners bot|owners-check', 'i');
+
     this.git = new Git(context);
     this.context = context;
     this.github = context.github;
@@ -156,7 +158,7 @@ class PullRequest {
       conclusion,
       completed_at: new Date(),
       output: {
-        title: `${this.name} reviewers check`,
+        title: this.name,
         summary: `The check was a ${conclusion}!`,
         text,
       }
@@ -170,9 +172,10 @@ class PullRequest {
       check_run_id: checkRun.id,
       status: 'completed',
       conclusion,
+      name: this.name,
       completed_at: new Date(),
       output: {
-        title: `${this.name} reviewers check`,
+        title: this.name,
         summary: `The check was a ${conclusion}!`,
         text,
       }
@@ -195,7 +198,7 @@ class PullRequest {
   hasCheckRun(checkRuns) {
     const hasCheckRun = checkRuns.total_count > 0;
     const [checkRun] = checkRuns.check_runs.filter(x => {
-      return x.head_sha === this.headSha && /owners bot/i.test(x.name);
+      return x.head_sha === this.headSha && this.nameMatcher.test(x.name);
     });
     const tuple = {hasCheckRun: hasCheckRun && !!checkRun, checkRun};
     this.context.log.debug('[hasCheckRun]', tuple);
@@ -217,7 +220,7 @@ class PullRequest {
           return ` - ${file.path}\n`;
         });
         return `\n${fileOwnerHeader}${files}`;
-      }).join('  ');
+      }).join('');
     this.context.log.debug('[buildCheckOutput]', text);
     return text;
   }

--- a/test/fixtures/check-runs.get.35.json
+++ b/test/fixtures/check-runs.get.35.json
@@ -20,7 +20,7 @@
                 "annotations_count": 0,
                 "annotations_url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313/annotations"
             },
-            "name": "My app!",
+            "name": "ampproject/owners-check",
             "check_suite": {
                 "id": 52508974
             },

--- a/test/fixtures/check-runs.get.35.multiple.json
+++ b/test/fixtures/check-runs.get.35.multiple.json
@@ -1,0 +1,163 @@
+{
+    "total_count": 1,
+    "check_runs": [
+        {
+            "id": 53472315,
+            "node_id": "MDg6Q2hlY2tSdW41MzQ3MjMxMw==",
+            "head_sha": "9272f18514cbd3fa935b3ced62ae1c2bf6efa76d",
+            "external_id": "",
+            "url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313",
+            "html_url": "https://github.com/erwinmombay/github-owners-bot-test-repo/runs/53472313",
+            "details_url": "https://www.ampproject.org",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2019-01-23T03:33:53Z",
+            "completed_at": "2019-01-23T03:33:52Z",
+            "output": {
+                "title": "Probot check!",
+                "summary": "The check has passed!",
+                "text": null,
+                "annotations_count": 0,
+                "annotations_url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313/annotations"
+            },
+            "name": "ampproject/owners-check",
+            "check_suite": {
+                "id": 52508974
+            },
+            "app": {
+                "id": 22611,
+                "node_id": "MDM6QXBwMjI2MTE=",
+                "owner": {
+                    "login": "ampprojectbot",
+                    "id": 23269078,
+                    "node_id": "MDQ6VXNlcjIzMjY5MDc4",
+                    "avatar_url": "https://avatars3.githubusercontent.com/u/23269078?v=4",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/ampprojectbot",
+                    "html_url": "https://github.com/ampprojectbot",
+                    "followers_url": "https://api.github.com/users/ampprojectbot/followers",
+                    "following_url": "https://api.github.com/users/ampprojectbot/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/ampprojectbot/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/ampprojectbot/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/ampprojectbot/subscriptions",
+                    "organizations_url": "https://api.github.com/users/ampprojectbot/orgs",
+                    "repos_url": "https://api.github.com/users/ampprojectbot/repos",
+                    "events_url": "https://api.github.com/users/ampprojectbot/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/ampprojectbot/received_events",
+                    "type": "User",
+                    "site_admin": false
+                },
+                "name": "amp-owners-bot",
+                "description": "A bot that verifies that all \"owners\" of a file set has approved a pull request.\r\n\r\nusers OWNERS.yaml files in a repository to find the set of owners.",
+                "external_url": "https://www.ampproject.org",
+                "html_url": "https://github.com/apps/amp-owners-bot",
+                "created_at": "2018-12-20T18:50:10Z",
+                "updated_at": "2019-01-18T19:48:17Z"
+            },
+            "pull_requests": [
+                {
+                    "url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/pulls/35",
+                    "id": 246688458,
+                    "number": 35,
+                    "head": {
+                        "ref": "ampprojectbot-patch-3",
+                        "sha": "9272f18514cbd3fa935b3ced62ae1c2bf6efa76d",
+                        "repo": {
+                            "id": 72889098,
+                            "url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo",
+                            "name": "github-owners-bot-test-repo"
+                        }
+                    },
+                    "base": {
+                        "ref": "master",
+                        "sha": "e896a1ed550e296573e46bcb7d0ab23afa3bbedf",
+                        "repo": {
+                            "id": 72889098,
+                            "url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo",
+                            "name": "github-owners-bot-test-repo"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "id": 53472313,
+            "node_id": "MDg6Q2hlY2tSdW41MzQ3MjMxMw==",
+            "head_sha": "9272f18514cbd3fa935b3ced62ae1c2bf6efa76d",
+            "external_id": "",
+            "url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313",
+            "html_url": "https://github.com/erwinmombay/github-owners-bot-test-repo/runs/53472313",
+            "details_url": "https://www.ampproject.org",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2019-01-23T03:33:53Z",
+            "completed_at": "2019-01-23T03:33:52Z",
+            "output": {
+                "title": "Probot check!",
+                "summary": "The check has passed!",
+                "text": null,
+                "annotations_count": 0,
+                "annotations_url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313/annotations"
+            },
+            "name": "some other check from the same bot",
+            "check_suite": {
+                "id": 52508974
+            },
+            "app": {
+                "id": 22611,
+                "node_id": "MDM6QXBwMjI2MTE=",
+                "owner": {
+                    "login": "ampprojectbot",
+                    "id": 23269078,
+                    "node_id": "MDQ6VXNlcjIzMjY5MDc4",
+                    "avatar_url": "https://avatars3.githubusercontent.com/u/23269078?v=4",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/ampprojectbot",
+                    "html_url": "https://github.com/ampprojectbot",
+                    "followers_url": "https://api.github.com/users/ampprojectbot/followers",
+                    "following_url": "https://api.github.com/users/ampprojectbot/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/ampprojectbot/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/ampprojectbot/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/ampprojectbot/subscriptions",
+                    "organizations_url": "https://api.github.com/users/ampprojectbot/orgs",
+                    "repos_url": "https://api.github.com/users/ampprojectbot/repos",
+                    "events_url": "https://api.github.com/users/ampprojectbot/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/ampprojectbot/received_events",
+                    "type": "User",
+                    "site_admin": false
+                },
+                "name": "amp-owners-bot",
+                "description": "A bot that verifies that all \"owners\" of a file set has approved a pull request.\r\n\r\nusers OWNERS.yaml files in a repository to find the set of owners.",
+                "external_url": "https://www.ampproject.org",
+                "html_url": "https://github.com/apps/amp-owners-bot",
+                "created_at": "2018-12-20T18:50:10Z",
+                "updated_at": "2019-01-18T19:48:17Z"
+            },
+            "pull_requests": [
+                {
+                    "url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/pulls/35",
+                    "id": 246688458,
+                    "number": 35,
+                    "head": {
+                        "ref": "ampprojectbot-patch-3",
+                        "sha": "9272f18514cbd3fa935b3ced62ae1c2bf6efa76d",
+                        "repo": {
+                            "id": 72889098,
+                            "url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo",
+                            "name": "github-owners-bot-test-repo"
+                        }
+                    },
+                    "base": {
+                        "ref": "master",
+                        "sha": "e896a1ed550e296573e46bcb7d0ab23afa3bbedf",
+                        "repo": {
+                            "id": 72889098,
+                            "url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo",
+                            "name": "github-owners-bot-test-repo"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Current implementation would not know which "check" to update if there were other check suites running on a pull request. we read the check name and look for "owners bot" to identify the specific suite and run we need to update from the payload.

also added additional logging stream since probot's default logging stream does not output to GCE logging